### PR TITLE
Allow for local dev configurations

### DIFF
--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -1,0 +1,12 @@
+<?php
+/*
+This is a sample local-config.php file
+In it, you *must* include the four main database defines
+
+You may include other settings here that you only want enabled on your local development checkouts
+*/
+
+define( 'DB_NAME', 'local_db_name' );
+define( 'DB_USER', 'local_db_user' );
+define( 'DB_PASSWORD', 'local_db_password' );
+define( 'DB_HOST', 'localhost' ); // Probably 'localhost'

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,18 +1,28 @@
 <?php
-$services = getenv("VCAP_SERVICES");
-$services_json = json_decode($services,true);
-$mysql_config = $services_json["mysql-5.1"][0]["credentials"];
+// ===================================================
+// Load database info and local development parameters
+// ===================================================
+if ( file_exists( dirname( __FILE__ ) . '/local-config.php' ) ) {
+	define( 'WP_LOCAL_DEV', true );
+	include( dirname( __FILE__ ) . '/local-config.php' );
+} else {
+	define( 'WP_LOCAL_DEV', false );
+	$services = getenv("VCAP_SERVICES");
+	$services_json = json_decode($services,true);
+	$mysql_config = $services_json["mysql-5.1"][0]["credentials"];
 
-// ** MySQL settings from resource descriptor ** //
-define('DB_NAME', $mysql_config["name"]);
-define('DB_USER', $mysql_config["user"]);
-define('DB_PASSWORD', $mysql_config["password"]);
-define('DB_HOST', $mysql_config["hostname"]);
-define('DB_PORT', $mysql_config["port"]);
+	// ** MySQL settings from resource descriptor ** //
+	define('DB_NAME', $mysql_config["name"]);
+	define('DB_USER', $mysql_config["user"]);
+	define('DB_PASSWORD', $mysql_config["password"]);
+	define('DB_HOST', $mysql_config["hostname"]);
+	define('DB_PORT', $mysql_config["port"]);
 
-define('DB_CHARSET', 'utf8');
-define('DB_COLLATE', '');
-define ('WPLANG', '');
+	define('DB_CHARSET', 'utf8');
+	define('DB_COLLATE', '');
+	define ('WPLANG', '');
+}
+
 define('WP_DEBUG', false);
 
 require('wp-salt.php');


### PR DESCRIPTION
In the style of [markjaquith/WordPress-Skeleton](https://github.com/markjaquith/WordPress-Skeleton), this should allow for us AppFog users to specify local configuration files in the same directory as our AppFog instance.

It first checks for local database configuration settings in `local-config.php`, and if not found will then resort to the VCAP_SERVICES config.
